### PR TITLE
point at path for index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Time zones with offsets and canonical links from the IANA Time Zone Database",
     "keywords": ["canonical", "offset", "tease", "time", "timezone", "tz", "tzone", "utc", "zone"],
     "license": "MIT",
-    "main": "src/index.js",
+    "main": "index.js",
     "scripts": {
         "test": "node_modules/.bin/mocha --ui tdd --reporter spec test.js"
     },


### PR DESCRIPTION
at least on my system, `index.js` lives at the top level package directory (not at `src/index.js`).